### PR TITLE
Add function bindings for docking

### DIFF
--- a/src/gui.zig
+++ b/src/gui.zig
@@ -666,6 +666,11 @@ extern fn zguiShowMetricsWindow(popen: ?*bool) void;
 // Windows
 //
 //--------------------------------------------------------------------------------------------------
+pub fn setNextWindowViewport(viewport_id: Ident) void {
+    zguiSetNextWindowViewport(viewport_id);
+}
+extern fn zguiSetNextWindowViewport(viewport_id: Ident) void;
+//--------------------------------------------------------------------------------------------------
 const SetNextWindowPos = struct {
     x: f32,
     y: f32,
@@ -3635,6 +3640,11 @@ extern fn zguiSetTabItemClosed(tab_or_docked_window_label: [*:0]const u8) void;
 //
 //--------------------------------------------------------------------------------------------------
 pub const Viewport = *opaque {
+    pub fn getId(viewport: Viewport) Ident {
+        return zguiViewport_GetId(viewport);
+    }
+    extern fn zguiViewport_GetId(viewport: Viewport) Ident;
+
     pub fn getPos(viewport: Viewport) [2]f32 {
         var pos: [2]f32 = undefined;
         zguiViewport_GetPos(viewport, &pos);

--- a/src/zgui.cpp
+++ b/src/zgui.cpp
@@ -34,6 +34,11 @@ extern "C"
         ImGui::SetAllocatorFunctions(alloc_func, free_func, nullptr);
     }
 
+    ZGUI_API void zguiSetNextWindowViewport(ImGuiID viewport_id)
+    {
+        ImGui::SetNextWindowViewport(viewport_id);
+    }
+
     ZGUI_API void zguiSetNextWindowPos(float x, float y, ImGuiCond cond, float pivot_x, float pivot_y)
     {
         ImGui::SetNextWindowPos({x, y}, cond, {pivot_x, pivot_y});
@@ -2533,6 +2538,11 @@ extern "C"
     ZGUI_API ImGuiViewport *zguiGetMainViewport(void)
     {
         return ImGui::GetMainViewport();
+    }
+
+    ZGUI_API ImGuiID zguiViewport_GetId(ImGuiViewport *viewport)
+    {
+        return viewport->ID;
     }
 
     ZGUI_API void zguiViewport_GetPos(ImGuiViewport *viewport, float p[2])


### PR DESCRIPTION
This is necessary to create an invisible dockspace covering the whole screen as described at
https://github.com/ocornut/imgui/issues/2109#issuecomment-426795391.