### PR TITLE
Proposal: Make zgui a module for emscripten

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ pub fn build(b: *std.Build) void {
         .with_implot = true,
     });
     exe.root_module.addImport("zgui", zgui.module("root"));
-    exe.linkLibrary(zgui.artifact("imgui"));
-    
+
     { // Needed for glfw/wgpu rendering backend
         const zglfw = b.dependency("zglfw", .{});
         exe.root_module.addImport("zglfw", zglfw.module("root"));

--- a/build.zig
+++ b/build.zig
@@ -317,7 +317,7 @@ pub fn build(b: *std.Build) void {
                 },
                 .flags = cflags,
             });
-            mod.linkSystemLibrary("d3dcompiler_47");
+            mod.linkSystemLibrary("d3dcompiler_47", .{});
         },
         .win32_dx12 => {
             mod.addCSourceFiles(.{
@@ -327,11 +327,11 @@ pub fn build(b: *std.Build) void {
                 },
                 .flags = cflags,
             });
-            mod.linkSystemLibrary("d3dcompiler_47");
-            mod.linkSystemLibrary("dwmapi");
+            mod.linkSystemLibrary("d3dcompiler_47", .{});
+            mod.linkSystemLibrary("dwmapi", .{});
             switch (target.result.abi) {
-                .msvc => mod.linkSystemLibrary("Gdi32"),
-                .gnu => mod.linkSystemLibrary("gdi32"),
+                .msvc => mod.linkSystemLibrary("Gdi32", .{}),
+                .gnu => mod.linkSystemLibrary("gdi32", .{}),
                 else => {},
             }
         },

--- a/build.zig
+++ b/build.zig
@@ -67,7 +67,7 @@ pub fn build(b: *std.Build) void {
 
     const options_module = options_step.createModule();
 
-    const mod = b.addModule("root", .{
+    const imgui = b.addModule("root", .{
         .root_source_file = b.path("src/gui.zig"),
         .imports = &.{
             .{ .name = "zgui_options", .module = options_module },
@@ -88,27 +88,27 @@ pub fn build(b: *std.Build) void {
     };
 
     if (target.result.os.tag == .windows) {
-        mod.addCMacro("IMGUI_API", "__declspec(dllexport)");
-        mod.addCMacro("IMPLOT_API", "__declspec(dllexport)");
-        mod.addCMacro("ZGUI_API", "__declspec(dllexport)");
+        imgui.addCMacro("IMGUI_API", "__declspec(dllexport)");
+        imgui.addCMacro("IMPLOT_API", "__declspec(dllexport)");
+        imgui.addCMacro("ZGUI_API", "__declspec(dllexport)");
     }
 
-    mod.addIncludePath(b.path("libs"));
-    mod.addIncludePath(b.path("libs/imgui"));
+    imgui.addIncludePath(b.path("libs"));
+    imgui.addIncludePath(b.path("libs/imgui"));
 
     const emscripten = target.result.os.tag == .emscripten;
     if (!emscripten) {
-        mod.link_libc = true;
+        imgui.link_libc = true;
         if (target.result.abi != .msvc)
-            mod.link_libcpp = true;
+            imgui.link_libcpp = true;
     }
 
-    mod.addCSourceFile(.{
+    imgui.addCSourceFile(.{
         .file = b.path("src/zgui.cpp"),
         .flags = cflags,
     });
 
-    mod.addCSourceFiles(.{
+    imgui.addCSourceFiles(.{
         .files = &.{
             "libs/imgui/imgui.cpp",
             "libs/imgui/imgui_widgets.cpp",
@@ -121,28 +121,28 @@ pub fn build(b: *std.Build) void {
 
     if (options.with_freetype) {
         if (b.lazyDependency("freetype", .{})) |freetype| {
-            mod.linkLibrary(freetype.artifact("freetype"));
+            imgui.linkLibrary(freetype.artifact("freetype"));
         }
-        mod.addCSourceFile(.{
+        imgui.addCSourceFile(.{
             .file = b.path("libs/imgui/misc/freetype/imgui_freetype.cpp"),
             .flags = cflags,
         });
-        mod.addCMacro("IMGUI_ENABLE_FREETYPE", "1");
+        imgui.addCMacro("IMGUI_ENABLE_FREETYPE", "1");
     }
 
     if (options.use_wchar32) {
-        mod.addCMacro("IMGUI_USE_WCHAR32", "1");
+        imgui.addCMacro("IMGUI_USE_WCHAR32", "1");
     }
 
     if (options.with_implot) {
-        mod.addIncludePath(b.path("libs/implot"));
+        imgui.addIncludePath(b.path("libs/implot"));
 
-        mod.addCSourceFile(.{
+        imgui.addCSourceFile(.{
             .file = b.path("src/zplot.cpp"),
             .flags = cflags,
         });
 
-        mod.addCSourceFiles(.{
+        imgui.addCSourceFiles(.{
             .files = &.{
                 "libs/implot/implot_demo.cpp",
                 "libs/implot/implot.cpp",
@@ -153,14 +153,14 @@ pub fn build(b: *std.Build) void {
     }
 
     if (options.with_gizmo) {
-        mod.addIncludePath(b.path("libs/imguizmo/"));
+        imgui.addIncludePath(b.path("libs/imguizmo/"));
 
-        mod.addCSourceFile(.{
+        imgui.addCSourceFile(.{
             .file = b.path("src/zgizmo.cpp"),
             .flags = cflags,
         });
 
-        mod.addCSourceFiles(.{
+        imgui.addCSourceFiles(.{
             .files = &.{
                 "libs/imguizmo/ImGuizmo.cpp",
             },
@@ -169,36 +169,36 @@ pub fn build(b: *std.Build) void {
     }
 
     if (options.with_node_editor) {
-        mod.addCSourceFile(.{
+        imgui.addCSourceFile(.{
             .file = b.path("src/znode_editor.cpp"),
             .flags = cflags,
         });
 
-        mod.addCSourceFile(.{ .file = b.path("libs/node_editor/crude_json.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_canvas.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_node_editor_api.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_node_editor.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/node_editor/crude_json.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_canvas.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_node_editor_api.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/node_editor/imgui_node_editor.cpp"), .flags = cflags });
     }
 
     if (options.with_te) {
-        mod.addCSourceFile(.{
+        imgui.addCSourceFile(.{
             .file = b.path("src/zte.cpp"),
             .flags = cflags,
         });
 
-        mod.addCMacro("IMGUI_ENABLE_TEST_ENGINE", "");
-        mod.addCMacro("IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL", "1");
+        imgui.addCMacro("IMGUI_ENABLE_TEST_ENGINE", "");
+        imgui.addCMacro("IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL", "1");
 
-        mod.addIncludePath(b.path("libs/imgui_test_engine/"));
+        imgui.addIncludePath(b.path("libs/imgui_test_engine/"));
 
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_capture_tool.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_context.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_coroutine.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_engine.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_exporters.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_perftool.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_ui.cpp"), .flags = cflags });
-        mod.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_utils.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_capture_tool.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_context.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_coroutine.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_engine.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_exporters.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_perftool.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_ui.cpp"), .flags = cflags });
+        imgui.addCSourceFile(.{ .file = b.path("libs/imgui_test_engine/imgui_te_utils.cpp"), .flags = cflags });
 
         // TODO: Workaround because zig on win64 doesn have phtreads
         // TODO: Implement corutine in zig can solve this
@@ -238,18 +238,18 @@ pub fn build(b: *std.Build) void {
             winpthreads.addIncludePath(b.path("libs/winpthreads/include"));
             winpthreads.addIncludePath(b.path("libs/winpthreads/src"));
             winpthreads.linkLibC();
-            mod.linkLibrary(winpthreads);
-            mod.addSystemIncludePath(b.path("libs/winpthreads/include"));
+            imgui.linkLibrary(winpthreads);
+            imgui.addSystemIncludePath(b.path("libs/winpthreads/include"));
         }
     }
 
     switch (options.backend) {
         .glfw_wgpu => {
             if (emscripten) {
-                mod.addSystemIncludePath(.{
+                imgui.addSystemIncludePath(.{
                     .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "include" }),
                 });
-                mod.addCSourceFiles(.{
+                imgui.addCSourceFiles(.{
                     .files = &.{
                         "libs/imgui/backends/imgui_impl_glfw.cpp",
                         "libs/imgui/backends/imgui_impl_wgpu.cpp",
@@ -258,12 +258,12 @@ pub fn build(b: *std.Build) void {
                 });
             } else {
                 if (b.lazyDependency("zglfw", .{})) |zglfw| {
-                    mod.addIncludePath(zglfw.path("libs/glfw/include"));
+                    imgui.addIncludePath(zglfw.path("libs/glfw/include"));
                 }
                 if (b.lazyDependency("zgpu", .{})) |zgpu| {
-                    mod.addIncludePath(zgpu.path("libs/dawn/include"));
+                    imgui.addIncludePath(zgpu.path("libs/dawn/include"));
                 }
-                mod.addCSourceFiles(.{
+                imgui.addCSourceFiles(.{
                     .files = &.{
                         "libs/imgui/backends/imgui_impl_glfw.cpp",
                         "libs/imgui/backends/imgui_impl_wgpu.cpp",
@@ -274,9 +274,9 @@ pub fn build(b: *std.Build) void {
         },
         .glfw_opengl3 => {
             if (b.lazyDependency("zglfw", .{})) |zglfw| {
-                mod.addIncludePath(zglfw.path("libs/glfw/include"));
+                imgui.addIncludePath(zglfw.path("libs/glfw/include"));
             }
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_opengl3.cpp",
@@ -286,39 +286,39 @@ pub fn build(b: *std.Build) void {
         },
         .glfw_dx12 => {
             if (b.lazyDependency("zglfw", .{})) |zglfw| {
-                mod.addIncludePath(zglfw.path("libs/glfw/include"));
+                imgui.addIncludePath(zglfw.path("libs/glfw/include"));
             }
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_dx12.cpp",
                 },
                 .flags = cflags,
             });
-            mod.linkSystemLibrary("d3dcompiler_47", .{});
+            imgui.linkSystemLibrary("d3dcompiler_47", .{});
         },
         .win32_dx12 => {
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_win32.cpp",
                     "libs/imgui/backends/imgui_impl_dx12.cpp",
                 },
                 .flags = cflags,
             });
-            mod.linkSystemLibrary("d3dcompiler_47", .{});
-            mod.linkSystemLibrary("dwmapi", .{});
+            imgui.linkSystemLibrary("d3dcompiler_47", .{});
+            imgui.linkSystemLibrary("dwmapi", .{});
             switch (target.result.abi) {
-                .msvc => mod.linkSystemLibrary("Gdi32", .{}),
-                .gnu => mod.linkSystemLibrary("gdi32", .{}),
+                .msvc => imgui.linkSystemLibrary("Gdi32", .{}),
+                .gnu => imgui.linkSystemLibrary("gdi32", .{}),
                 else => {},
             }
         },
         .glfw_vulkan => {
             if (b.lazyDependency("zglfw", .{})) |zglfw| {
-                mod.addIncludePath(zglfw.path("libs/glfw/include"));
+                imgui.addIncludePath(zglfw.path("libs/glfw/include"));
             }
 
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_vulkan.cpp",
@@ -328,9 +328,9 @@ pub fn build(b: *std.Build) void {
         },
         .glfw => {
             if (b.lazyDependency("zglfw", .{})) |zglfw| {
-                mod.addIncludePath(zglfw.path("libs/glfw/include"));
+                imgui.addIncludePath(zglfw.path("libs/glfw/include"));
             }
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                 },
@@ -339,9 +339,9 @@ pub fn build(b: *std.Build) void {
         },
         .sdl2_opengl3 => {
             if (b.lazyDependency("zsdl", .{})) |zsdl| {
-                mod.addIncludePath(zsdl.path("libs/sdl2/include"));
+                imgui.addIncludePath(zsdl.path("libs/sdl2/include"));
             }
-            mod.addCSourceFiles(.{
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_sdl2.cpp",
                     "libs/imgui/backends/imgui_impl_opengl3.cpp",
@@ -350,11 +350,11 @@ pub fn build(b: *std.Build) void {
             });
         },
         .osx_metal => {
-            mod.linkFramework("Foundation", .{});
-            mod.linkFramework("Metal", .{});
-            mod.linkFramework("Cocoa", .{});
-            mod.linkFramework("QuartzCore", .{});
-            mod.addCSourceFiles(.{
+            imgui.linkFramework("Foundation", .{});
+            imgui.linkFramework("Metal", .{});
+            imgui.linkFramework("Cocoa", .{});
+            imgui.linkFramework("QuartzCore", .{});
+            imgui.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_osx.mm",
                     "libs/imgui/backends/imgui_impl_metal.mm",
@@ -367,8 +367,8 @@ pub fn build(b: *std.Build) void {
 
     if (target.result.os.tag == .macos) {
         if (b.lazyDependency("system_sdk", .{})) |system_sdk| {
-            mod.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
-            mod.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
+            imgui.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
+            imgui.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
         }
     }
 
@@ -383,7 +383,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(tests);
 
     tests.root_module.addImport("zgui_options", options_module);
-    tests.root_module.addImport("zgui", mod);
+    tests.root_module.addImport("zgui", imgui);
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -372,10 +372,10 @@ pub fn build(b: *std.Build) void {
             });
         },
         .osx_metal => {
-            mod.linkFramework("Foundation");
-            mod.linkFramework("Metal");
-            mod.linkFramework("Cocoa");
-            mod.linkFramework("QuartzCore");
+            mod.linkFramework("Foundation", .{});
+            mod.linkFramework("Metal", .{});
+            mod.linkFramework("Cocoa", .{});
+            mod.linkFramework("QuartzCore", .{});
             mod.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_osx.mm",

--- a/build.zig
+++ b/build.zig
@@ -249,6 +249,13 @@ pub fn build(b: *std.Build) void {
                 mod.addSystemIncludePath(.{
                     .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "include" }),
                 });
+                mod.addCSourceFiles(.{
+                    .files = &.{
+                        "libs/imgui/backends/imgui_impl_glfw.cpp",
+                        "libs/imgui/backends/imgui_impl_wgpu.cpp",
+                    },
+                    .flags = cflags,
+                });
             } else {
                 if (b.lazyDependency("zglfw", .{})) |zglfw| {
                     mod.addIncludePath(zglfw.path("libs/glfw/include"));
@@ -256,14 +263,14 @@ pub fn build(b: *std.Build) void {
                 if (b.lazyDependency("zgpu", .{})) |zgpu| {
                     mod.addIncludePath(zgpu.path("libs/dawn/include"));
                 }
+                mod.addCSourceFiles(.{
+                    .files = &.{
+                        "libs/imgui/backends/imgui_impl_glfw.cpp",
+                        "libs/imgui/backends/imgui_impl_wgpu.cpp",
+                    },
+                    .flags = &(cflags.* ++ .{"-DIMGUI_IMPL_WEBGPU_BACKEND_WGPU"}),
+                });
             }
-            mod.addCSourceFiles(.{
-                .files = &.{
-                    "libs/imgui/backends/imgui_impl_glfw.cpp",
-                    "libs/imgui/backends/imgui_impl_wgpu.cpp",
-                },
-                .flags = cflags,
-            });
         },
         .glfw_opengl3 => {
             if (b.lazyDependency("zglfw", .{})) |zglfw| {

--- a/build.zig
+++ b/build.zig
@@ -87,11 +87,15 @@ pub fn build(b: *std.Build) void {
         "-Wno-availability",
     };
 
-    if (target.result.os.tag == .windows) {
-        imgui.addCMacro("IMGUI_API", "__declspec(dllexport)");
-        imgui.addCMacro("IMPLOT_API", "__declspec(dllexport)");
-        imgui.addCMacro("ZGUI_API", "__declspec(dllexport)");
-    }
+    //Shared Library details
+    //if (target.result.os.tag == .macos) {
+    //    lib.linker_allow_shlib_undefined = true;
+    //}
+    //if (target.result.os.tag == .windows) {
+    //    imgui.addCMacro("IMGUI_API", "__declspec(dllexport)");
+    //    imgui.addCMacro("IMPLOT_API", "__declspec(dllexport)");
+    //    imgui.addCMacro("ZGUI_API", "__declspec(dllexport)");
+    //}
 
     imgui.addIncludePath(b.path("libs"));
     imgui.addIncludePath(b.path("libs/imgui"));

--- a/libs/imgui/backends/imgui_impl_wgpu.cpp
+++ b/libs/imgui/backends/imgui_impl_wgpu.cpp
@@ -45,19 +45,6 @@
 // When targeting native platforms (i.e. NOT emscripten), one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 // or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be provided. See imgui_impl_wgpu.h for more details.
 
-// FIX(zig-gamedev)
-#define IMGUI_IMPL_WEBGPU_BACKEND_WGPU
-
-#ifndef __EMSCRIPTEN__
-    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) == defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-    #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
-    #endif
-#else
-    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-    #error neither IMGUI_IMPL_WEBGPU_BACKEND_DAWN nor IMGUI_IMPL_WEBGPU_BACKEND_WGPU may be defined if targeting emscripten!
-    #endif
-#endif
-
 #include "imgui.h"
 #ifndef IMGUI_DISABLE
 
@@ -836,8 +823,6 @@ bool ImGui_ImplWGPU_Init(ImGui_ImplWGPU_InitInfo* init_info)
     io.BackendRendererName = "imgui_impl_webgpu_emscripten";
 #elif defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN)
     io.BackendRendererName = "imgui_impl_webgpu_dawn";
-#elif defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-    io.BackendRendererName = "imgui_impl_webgpu_wgpu";
 #else
     io.BackendRendererName = "imgui_impl_webgpu";
 #endif

--- a/libs/imgui/backends/imgui_impl_wgpu.cpp
+++ b/libs/imgui/backends/imgui_impl_wgpu.cpp
@@ -45,6 +45,16 @@
 // When targeting native platforms (i.e. NOT emscripten), one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 // or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be provided. See imgui_impl_wgpu.h for more details.
 
+#ifndef __EMSCRIPTEN__
+    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) == defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
+    #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
+    #endif
+#else
+    #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
+    #error neither IMGUI_IMPL_WEBGPU_BACKEND_DAWN nor IMGUI_IMPL_WEBGPU_BACKEND_WGPU may be defined if targeting emscripten!
+    #endif
+#endif
+
 #include "imgui.h"
 #ifndef IMGUI_DISABLE
 

--- a/libs/imgui/backends/imgui_impl_wgpu.h
+++ b/libs/imgui/backends/imgui_impl_wgpu.h
@@ -8,9 +8,6 @@
 // This requirement will be removed once WebGPU stabilizes and backends converge on a unified interface.
 //#define IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 
-// FIX(zig-gamedev)
-#define IMGUI_IMPL_WEBGPU_BACKEND_WGPU
-
 // Implemented features:
 //  [X] Renderer: User texture binding. Use 'WGPUTextureView' as ImTextureID. Read the FAQ about ImTextureID!
 //  [X] Renderer: Large meshes support (64k+ vertices) even with 16-bit indices (ImGuiBackendFlags_RendererHasVtxOffset).


### PR DESCRIPTION
In order to build for emscripten, all library code must be imported into the wasm lib instead of linked. Zig modules seem to cover both emscripten and native builds. Also a fix in the underlying imgui lib can be removed and an additional C flag can be added to build for native wgpu.

Might be stomping on some toes by removing the shared / static library, maybe we should have a linked build and a module build side by side?

Tested against gui_test_wgpu for native and my project for native and web.