### PR TITLE
Restore 32bit draw index

### DIFF
--- a/libs/imgui/imconfig.h
+++ b/libs/imgui/imconfig.h
@@ -117,7 +117,9 @@
 // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
 // Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
 // Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
-//#define ImDrawIdx unsigned int
+#ifdef IMGUI_USE_32BIT_DRAW_INDEX
+#define ImDrawIdx unsigned int
+#endif
 
 //---- Override ImDrawCallback signature (will need to modify renderer backends accordingly)
 //struct ImDrawList;


### PR DESCRIPTION
32bit draw index was accidentally broken in #15, this just restores the old conditional in `imconfig.h`. This is probably bound to happen again but couldn't find a better solution. Maybe set the define directly in build.zig?