### PR TITLE
Add `updatePlatformWindows` and `renderPlatformWindowsDefault` functions

### DIFF
--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1801,10 +1801,10 @@ pub fn comboFromEnum(
 
     var item: i32 =
         switch (@typeInfo(EnumType)) {
-        .optional => if (current_item.*) |tag| field_name_to_index.get(@tagName(tag)) orelse -1 else -1,
-        .@"enum" => field_name_to_index.get(@tagName(current_item.*)) orelse -1,
-        else => unreachable,
-    };
+            .optional => if (current_item.*) |tag| field_name_to_index.get(@tagName(tag)) orelse -1 else -1,
+            .@"enum" => field_name_to_index.get(@tagName(current_item.*)) orelse -1,
+            else => unreachable,
+        };
 
     const result = combo(label, .{
         .items_separated_by_zeros = item_names,
@@ -3697,6 +3697,12 @@ pub const Viewport = *opaque {
 };
 pub const getMainViewport = zguiGetMainViewport;
 extern fn zguiGetMainViewport() Viewport;
+
+pub const updatePlatformWindows = zguiUpdatePlatformWindows;
+extern fn zguiUpdatePlatformWindows() void;
+
+pub const renderPlatformWindowsDefault = zguiRenderPlatformWindowsDefault;
+extern fn zguiRenderPlatformWindowsDefault() void;
 //--------------------------------------------------------------------------------------------------
 //
 // Mouse Input

--- a/src/zgui.cpp
+++ b/src/zgui.cpp
@@ -2573,6 +2573,14 @@ extern "C"
         p[1] = sz.y;
     }
 
+    ZGUI_API void zguiUpdatePlatformWindows() {
+        ImGui::UpdatePlatformWindows();
+    }
+
+    ZGUI_API void zguiRenderPlatformWindowsDefault() {
+        ImGui::RenderPlatformWindowsDefault();
+    }
+
     //--------------------------------------------------------------------------------------------------
     //
     // Docking


### PR DESCRIPTION
To make the `viewport_enable` `ConfigFlag` work we should call a `updatePlatformWindows` and `renderPlatformWindowsDefault`per [ImGui documentation](https://github.com/ocornut/imgui/wiki/Multi-Viewports).

```zig
zgui.io.setConfigFlags(.{
    .viewport_enable = true,
});

// ... later in the main loop
{ // Enable Multi-Viewports
    const ctx = glfw.getCurrentContext(); // this is need for opengl3 see https://github.com/ocornut/imgui/blob/docking/examples/example_glfw_opengl3/main.cpp
    zgui.updatePlatformWindows();
    zgui.renderPlatformWindowsDefault();
    glfw.makeContextCurrent(ctx);
}
```

I tested it on my project that use `zopengl` and `zglfw`.

Resolves #29 