### PR TITLE
Fix broken zig 0.14 build due to bad zsdl dependency

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -27,8 +27,8 @@
             .lazy = true,
         },
         .zsdl = .{
-            .url = "https://github.com/zig-gamedev/zsdl/archive/cd29a0b441e070e0ef38c02ba3e322ef19004a34.tar.gz",
-            .hash = "zsdl-0.4.0-dev-AAAAAABXWQDfNLmT5yuYIunIkrWPRtuY4bQdUvjFHbut",
+            .url = "https://github.com/zig-gamedev/zsdl/archive/b0804762a2277dcfe8a52d3ae86112a4c47c8d73.tar.gz",
+            .hash = "zsdl-0.4.0-dev-rFpjE2lXWQDkQzXKp_gIQ0ynAQ3NiB_ABpx0Xwxu5P8j",
             .lazy = true,
         },
         .freetype = .{


### PR DESCRIPTION
Fixes an issue where `zgui` brings in a non-0.14 compatible version of `zsdl`, breaking the final build.

This only seems to happen if you use all of `zgui` + `zsdl` + `zsdl-prebuilt*`.

My understanding of the problem is:

* `zsdl` was updated to support the new `build.zig` syntax in https://github.com/zig-gamedev/zsdl/commit/b0804762a2277dcfe8a52d3ae86112a4c47c8d73
* However `zgui` has an optional dependency pointing to https://github.com/zig-gamedev/zsdl/commit/cd29a0b441e070e0ef38c02ba3e322ef19004a34 which doesn't include these changes
* Zig decides to pull in both versions of `zsdl`, therefore pulling in the old and new versions of the prebuilt libraries at the same time.
* The old prebuilt libraries use `.@"sdl2-prebuilt-macos"` which isn't supported, but Zig appears to suggest the error is coming from the new library (or at least is confusingly worded)

Bumping the dependency fixes things for me