### PR TITLE
Fix wgpu dpi scaling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -241,7 +241,7 @@ pub fn build(b: *std.Build) void {
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_wgpu.cpp",
                 },
-                .flags = cflags,
+                .flags = &(cflags.* ++ .{"-DGLFW_INCLUDE_NONE"}),
             });
         },
         .glfw_opengl3 => {
@@ -265,7 +265,7 @@ pub fn build(b: *std.Build) void {
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_dx12.cpp",
                 },
-                .flags = cflags,
+                .flags = &(cflags.* ++ .{"-DGLFW_INCLUDE_NONE"}),
             });
             imgui.linkSystemLibrary("d3dcompiler_47");
         },

--- a/build.zig
+++ b/build.zig
@@ -241,7 +241,11 @@ pub fn build(b: *std.Build) void {
                     "libs/imgui/backends/imgui_impl_glfw.cpp",
                     "libs/imgui/backends/imgui_impl_wgpu.cpp",
                 },
-                .flags = &(cflags.* ++ .{"-DGLFW_INCLUDE_NONE"}),
+                .flags = &(cflags.* ++ .{
+                    "-DGLFW_INCLUDE_NONE",
+                    // TODO: This should be IMGUI_IMPL_WEBGPU_BACKEND_DAWN but we're using an old version of Dawn that looks more like wgpu_native
+                    "-DIMGUI_IMPL_WEBGPU_BACKEND_WGPU",
+                }),
             });
         },
         .glfw_opengl3 => {

--- a/libs/imgui/backends/imgui_impl_glfw.h
+++ b/libs/imgui/backends/imgui_impl_glfw.h
@@ -11,7 +11,9 @@
 //  [X] Platform: Mouse cursor shape and visibility (ImGuiBackendFlags_HasMouseCursors). Resizing cursors requires GLFW 3.4+! Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
 //  [X] Platform: Multi-viewport support (multiple windows). Enable with 'io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable'.
 // Missing features or Issues:
-//  [ ] Platform: Multi-viewport: ParentViewportID not honored, and so io.ConfigViewportsNoDefaultParent has no effect (minor).
+//  [ ] Touch events are only correctly identified as Touch on Windows. This create issues with some interactions. GLFW doesn't provide a way to identify touch inputs from mouse inputs, we cannot call io.AddMouseSourceEvent() to identify the source. We provide a Windows-specific workaround.
+//  [ ] Missing ImGuiMouseCursor_Wait and ImGuiMouseCursor_Progress cursors.
+//  [ ] Multi-viewport: ParentViewportID not honored, and so io.ConfigViewportsNoDefaultParent has no effect (minor).
 
 // You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
 // Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
@@ -29,11 +31,13 @@ struct GLFWwindow;
 struct GLFWmonitor;
 
 // Follow "Getting Started" link and check examples/ folder to learn about using backends!
-IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOpenGL(GLFWwindow* window, bool install_callbacks);
-IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForVulkan(GLFWwindow* window, bool install_callbacks);
-IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOther(GLFWwindow* window, bool install_callbacks);
-IMGUI_IMPL_API void     ImGui_ImplGlfw_Shutdown();
-IMGUI_IMPL_API void     ImGui_ImplGlfw_NewFrame();
+extern "C" { // fix(zig-gamedev)
+  IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOpenGL(GLFWwindow* window, bool install_callbacks);
+  IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForVulkan(GLFWwindow* window, bool install_callbacks);
+  IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOther(GLFWwindow* window, bool install_callbacks);
+  IMGUI_IMPL_API void     ImGui_ImplGlfw_Shutdown();
+  IMGUI_IMPL_API void     ImGui_ImplGlfw_NewFrame();
+};
 
 // Emscripten related initialization phase methods (call after ImGui_ImplGlfw_InitForOpenGL)
 #ifdef __EMSCRIPTEN__

--- a/libs/imgui/backends/imgui_impl_wgpu.cpp
+++ b/libs/imgui/backends/imgui_impl_wgpu.cpp
@@ -399,7 +399,8 @@ static void ImGui_ImplWGPU_SetupRenderState(ImDrawData* draw_data, WGPURenderPas
     }
 
     // Setup viewport
-    wgpuRenderPassEncoderSetViewport(ctx, 0, 0, draw_data->FramebufferScale.x * draw_data->DisplaySize.x, draw_data->FramebufferScale.y * draw_data->DisplaySize.y, 0, 1);
+    // fix(zig-gamedev): Workaround https://github.com/gfx-rs/wgpu/issues/1958 until we can update Dawn
+    wgpuRenderPassEncoderSetViewport(ctx, 0, 0, (float)(int)(draw_data->FramebufferScale.x * draw_data->DisplaySize.x), (float)(int)(draw_data->FramebufferScale.y * draw_data->DisplaySize.y), 0, 1);
 
     // Bind shader and vertex buffers
     wgpuRenderPassEncoderSetVertexBuffer(ctx, 0, fr->VertexBuffer, 0, fr->VertexBufferSize * sizeof(ImDrawVert));

--- a/libs/imgui/backends/imgui_impl_wgpu.cpp
+++ b/libs/imgui/backends/imgui_impl_wgpu.cpp
@@ -45,9 +45,6 @@
 // When targeting native platforms (i.e. NOT emscripten), one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 // or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be provided. See imgui_impl_wgpu.h for more details.
 
-// FIX(zig-gamedev)
-#define IMGUI_IMPL_WEBGPU_BACKEND_WGPU
-
 #ifndef __EMSCRIPTEN__
     #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) == defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
     #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
@@ -61,8 +58,7 @@
 #include "imgui.h"
 #ifndef IMGUI_DISABLE
 
-// FIX(zig-gamedev):
-// #include "imgui_impl_wgpu.h"
+#include "imgui_impl_wgpu.h"
 
 #include <limits.h>
 #include <webgpu/webgpu.h>
@@ -70,47 +66,6 @@
 // Dear ImGui prototypes from imgui_internal.h
 extern ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed = 0);
 #define MEMALIGN(_SIZE,_ALIGN)        (((_SIZE) + ((_ALIGN) - 1)) & ~((_ALIGN) - 1))    // Memory align (copied from IM_ALIGN() macro).
-
-// FIX(zig-gamedev): We removed header file and declare all our external functions here.
-extern "C" {
-
-// Initialization data, for ImGui_ImplWGPU_Init()
-struct ImGui_ImplWGPU_InitInfo
-{
-    WGPUDevice              Device;
-    int                     NumFramesInFlight = 3;
-    WGPUTextureFormat       RenderTargetFormat = WGPUTextureFormat_Undefined;
-    WGPUTextureFormat       DepthStencilFormat = WGPUTextureFormat_Undefined;
-    WGPUMultisampleState    PipelineMultisampleState = {};
-
-    ImGui_ImplWGPU_InitInfo()
-    {
-        PipelineMultisampleState.count = 1;
-        PipelineMultisampleState.mask = UINT32_MAX;
-        PipelineMultisampleState.alphaToCoverageEnabled = false;
-    }
-};
-
-// Follow "Getting Started" link and check examples/ folder to learn about using backends!
-IMGUI_IMPL_API bool ImGui_ImplWGPU_Init(ImGui_ImplWGPU_InitInfo* init_info);
-IMGUI_IMPL_API void ImGui_ImplWGPU_Shutdown();
-IMGUI_IMPL_API void ImGui_ImplWGPU_NewFrame();
-IMGUI_IMPL_API void ImGui_ImplWGPU_RenderDrawData(ImDrawData* draw_data, WGPURenderPassEncoder pass_encoder);
-
-// Use if you want to reset your rendering device without losing Dear ImGui state.
-IMGUI_IMPL_API bool ImGui_ImplWGPU_CreateDeviceObjects();
-IMGUI_IMPL_API void ImGui_ImplWGPU_InvalidateDeviceObjects();
-
-// [BETA] Selected render state data shared with callbacks.
-// This is temporarily stored in GetPlatformIO().Renderer_RenderState during the ImGui_ImplWGPU_RenderDrawData() call.
-// (Please open an issue if you feel you need access to more data)
-struct ImGui_ImplWGPU_RenderState
-{
-    WGPUDevice                  Device;
-    WGPURenderPassEncoder       RenderPassEncoder;
-};
-
-} // extern "C"
 
 // WebGPU data
 struct RenderResources

--- a/libs/imgui/backends/imgui_impl_wgpu.h
+++ b/libs/imgui/backends/imgui_impl_wgpu.h
@@ -8,9 +8,6 @@
 // This requirement will be removed once WebGPU stabilizes and backends converge on a unified interface.
 //#define IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 
-// FIX(zig-gamedev)
-#define IMGUI_IMPL_WEBGPU_BACKEND_WGPU
-
 // Implemented features:
 //  [X] Renderer: User texture binding. Use 'WGPUTextureView' as ImTextureID. Read the FAQ about ImTextureID!
 //  [X] Renderer: Large meshes support (64k+ vertices) even with 16-bit indices (ImGuiBackendFlags_RendererHasVtxOffset).
@@ -31,6 +28,9 @@
 #ifndef IMGUI_DISABLE
 
 #include <webgpu/webgpu.h>
+
+// FIX(zig-gamedev)
+extern "C" {
 
 // Initialization data, for ImGui_ImplWGPU_Init()
 struct ImGui_ImplWGPU_InitInfo
@@ -67,5 +67,7 @@ struct ImGui_ImplWGPU_RenderState
     WGPUDevice                  Device;
     WGPURenderPassEncoder       RenderPassEncoder;
 };
+
+}
 
 #endif // #ifndef IMGUI_DISABLE

--- a/src/backend_glfw_wgpu.zig
+++ b/src/backend_glfw_wgpu.zig
@@ -30,13 +30,9 @@ pub fn deinit() void {
     backend_glfw.deinit();
 }
 
-pub fn newFrame(fb_width: u32, fb_height: u32) void {
-    ImGui_ImplWGPU_NewFrame();
+pub fn newFrame() void {
     backend_glfw.newFrame();
-
-    gui.io.setDisplaySize(@floatFromInt(fb_width), @floatFromInt(fb_height));
-    gui.io.setDisplayFramebufferScale(1.0, 1.0);
-
+    ImGui_ImplWGPU_NewFrame();
     gui.newFrame();
 }
 


### PR DESCRIPTION
- Updates glfw backend to imgui 1.91.8-docking (hack around Dawn/Vulkan bug)
- Fixes DPI scaling for glfw_wgpu backend
- Remove some superfluous hacks

This fixes DPI scaling for glfw_wgpu backend (https://github.com/zig-gamedev/zgui/issues/3) but exposes a bug in Dawn's vulkan backend. We work around this by ensuring the viewport size is clamped. However, there remains a validation error that results in a crash if the window size is increased; this appears to be a bug in the imgui wgpu backend, where the render target is not resized before the viewport is set.
```
error: [zgpu] Validation: Viewport bounds (x: 0.000000, y: 0.000000, width: 1927.000000, height: 1206.000000) are not contained in the render target dimensions (1920 x 1200).
 - While encoding [RenderPassEncoder].SetViewport(0.000000, 0.000000, 1927.000000, 1206.000000, 0.000000, 1.000000).
```
This ought to be fixed before this is merged.