### PR TITLE
Added plotLines() and plotHistogram()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ zig-out
 
 # Ignore some special OS files
 *.DS_Store
+
+# Ignore local example builds
+example/*

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1830,24 +1830,64 @@ extern fn zguiTextLinkOpenURL(label: [*:0]const u8, url: ?[*:0]const u8) void;
 pub const textLinkOpenURL = zguiTextLinkOpenURL;
 //--------------------------------------------------------------------------------------------------
 const PlotNative = struct {
-    v: *f32,
+    v: [*]f32,
     v_count: c_int,
     v_offset: c_int = 0,
-    overlay_text: ?[:0]const u8 = null,
+    overlay: ?[:0]const u8 = null,
     scale_min: f32 = f32_max,
-    scale_max: f32 = f32_min,
+    scale_max: f32 = f32_max,
     graph_size: [2]f32 = .{ 0, 0 },
     stride: c_int = @sizeOf(f32),
 };
 pub fn plotLines(label: [*:0]const u8, args: PlotNative) void {
-    zguiPlotLines(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+    zguiPlotLines(
+        label,
+        args.v,
+        args.v_count,
+        args.v_offset,
+        if (args.overlay) |o| o else null,
+        args.scale_min,
+        args.scale_max,
+        &args.graph_size,
+        args.stride,
+    );
 }
-extern fn zguiPlotLines(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+extern fn zguiPlotLines(
+    label: [*:0]const u8,
+    v: [*]f32,
+    v_count: c_int,
+    v_offset: c_int,
+    overlay: ?[*:0]const u8,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: *const [2]f32,
+    stride: c_int,
+) void;
 
 pub fn plotHistogram(label: [*:0]const u8, args: PlotNative) void {
-    zguiPlotHistogram(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+    zguiPlotHistogram(
+        label,
+        args.v,
+        args.v_count,
+        args.v_offset,
+        if (args.overlay) |o| o else null,
+        args.scale_min,
+        args.scale_max,
+        &args.graph_size,
+        args.stride,
+    );
 }
-extern fn zguiPlotHistogram(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+extern fn zguiPlotHistogram(
+    label: [*:0]const u8,
+    v: [*]f32,
+    v_count: c_int,
+    v_offset: c_int,
+    overlay: ?[*:0]const u8,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: *const [2]f32,
+    stride: c_int,
+) void;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1828,6 +1828,26 @@ pub const textLink = zguiTextLink;
 
 extern fn zguiTextLinkOpenURL(label: [*:0]const u8, url: ?[*:0]const u8) void;
 pub const textLinkOpenURL = zguiTextLinkOpenURL;
+//--------------------------------------------------------------------------------------------------
+const PlotNative = struct {
+    v: *f32,
+    v_count: c_int,
+    v_offset: c_int = 0,
+    overlay_text: ?[:0]const u8 = null,
+    scale_min: f32 = f32_max,
+    scale_max: f32 = f32_min,
+    graph_size: [2]f32 = .{ 0, 0 },
+    stride: c_int = @sizeOf(f32),
+};
+pub fn plotLines(label: [*:0]const u8, args: PlotNative) void {
+    zguiPlotLines(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+}
+extern fn zguiPlotLines(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+
+pub fn plotHistogram(label: [*:0]const u8, args: PlotNative) void {
+    zguiPlotHistogram(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+}
+extern fn zguiPlotHistogram(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/zgui.cpp
+++ b/src/zgui.cpp
@@ -1977,6 +1977,36 @@ extern "C"
     {
         ImGui::CloseCurrentPopup();
     }
+
+    ZGUI_API void zguiPlotLines(
+        const char* label, 
+        const float* values, 
+        int values_count, 
+        int values_offset, 
+        const char* overlay_text, 
+        float scale_min, 
+        float scale_max, 
+        float graph_size[2], 
+        int stride)
+    {
+        ImGui::PlotLines(label, values, values_count, values_offset, overlay_text, scale_min, scale_max, ImVec2(graph_size[0], graph_size[1]), stride);
+    }  
+    
+
+    ZGUI_API void zguiPlotHistogram(
+        const char* label, 
+        const float* values, 
+        int values_count, 
+        int values_offset, 
+        const char* overlay_text, 
+        float scale_min, 
+        float scale_max, 
+        float graph_size[2], 
+        int stride)
+    {
+        ImGui::PlotHistogram(label, values, values_count, values_offset, overlay_text, scale_min, scale_max, ImVec2(graph_size[0], graph_size[1]), stride);
+    }
+
     //--------------------------------------------------------------------------------------------------
     //
     // Tables


### PR DESCRIPTION
Because of the issue [Add vanilla PlotLines binding by taylorh140](https://github.com/zig-gamedev/zgui/issues/6) while I have use cases with the native plot functions, I have studied the library to see how to enable these functions. With extended the zgui.cpp and gui.zig, I have successfully enable these to functions as shown:

<img width="802" height="539" alt="image" src="https://github.com/user-attachments/assets/dbfee4ce-4718-4285-8aea-19bfd8afb117" />

The inconsistent plot size is intentional because I was also trying to change the properties passed with a newly created struct named PlotNative used for the two plot functions; thus, the function call should aligns the conventions of other existing function as shown:

```
// plotLines(label: [*:0]const u8, args: PlotNative)
// plotHistogram(label: [*:0]const u8, args: PlotNative)

zgui.plotLines("First Plot", .{ .v = &samples, .v_count = samples.len, .graph_size = .{ 0, 80 }, .overlay = "testing" });
zgui.plotLines("First small", .{ .v = &sample_small, .v_count = 7, .graph_size = .{ 240, 80 } });
zgui.plotHistogram("First Hist", .{ .v = &samples, .v_count = 100, .graph_size = .{ 0, 80 }, .overlay = "Another Label" });
zgui.plotHistogram("Hist small", .{ .v = &sample_small, .v_count = sample_small.len, .scale_min = 0, .graph_size = .{ 120, 80 } });
```

However, this is my first contribution, so please let me know if I have done a pull request properly.