### PR TITLE
Added addTextExtended and addTextExtendedUnformatted for additional AddText Functionalities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,3 @@ zig-out
 
 # Ignore some special OS files
 *.DS_Store
-
-# Ignore local example builds
-example/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ zig-out
 
 # Ignore some special OS files
 *.DS_Store
+
+# Ignore local example builds
+example/*

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1830,24 +1830,64 @@ extern fn zguiTextLinkOpenURL(label: [*:0]const u8, url: ?[*:0]const u8) void;
 pub const textLinkOpenURL = zguiTextLinkOpenURL;
 //--------------------------------------------------------------------------------------------------
 const PlotNative = struct {
-    v: *f32,
+    v: [*]f32,
     v_count: c_int,
     v_offset: c_int = 0,
-    overlay_text: ?[:0]const u8 = null,
+    overlay: ?[:0]const u8 = null,
     scale_min: f32 = f32_max,
-    scale_max: f32 = f32_min,
+    scale_max: f32 = f32_max,
     graph_size: [2]f32 = .{ 0, 0 },
     stride: c_int = @sizeOf(f32),
 };
 pub fn plotLines(label: [*:0]const u8, args: PlotNative) void {
-    zguiPlotLines(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+    zguiPlotLines(
+        label,
+        args.v,
+        args.v_count,
+        args.v_offset,
+        if (args.overlay) |o| o else null,
+        args.scale_min,
+        args.scale_max,
+        &args.graph_size,
+        args.stride,
+    );
 }
-extern fn zguiPlotLines(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+extern fn zguiPlotLines(
+    label: [*:0]const u8,
+    v: [*]f32,
+    v_count: c_int,
+    v_offset: c_int,
+    overlay: ?[*:0]const u8,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: *const [2]f32,
+    stride: c_int,
+) void;
 
 pub fn plotHistogram(label: [*:0]const u8, args: PlotNative) void {
-    zguiPlotHistogram(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+    zguiPlotHistogram(
+        label,
+        args.v,
+        args.v_count,
+        args.v_offset,
+        if (args.overlay) |o| o else null,
+        args.scale_min,
+        args.scale_max,
+        &args.graph_size,
+        args.stride,
+    );
 }
-extern fn zguiPlotHistogram(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+extern fn zguiPlotHistogram(
+    label: [*:0]const u8,
+    v: [*]f32,
+    v_count: c_int,
+    v_offset: c_int,
+    overlay: ?[*:0]const u8,
+    scale_min: f32,
+    scale_max: f32,
+    graph_size: *const [2]f32,
+    stride: c_int,
+) void;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1828,6 +1828,26 @@ pub const textLink = zguiTextLink;
 
 extern fn zguiTextLinkOpenURL(label: [*:0]const u8, url: ?[*:0]const u8) void;
 pub const textLinkOpenURL = zguiTextLinkOpenURL;
+//--------------------------------------------------------------------------------------------------
+const PlotNative = struct {
+    v: *f32,
+    v_count: c_int,
+    v_offset: c_int = 0,
+    overlay_text: ?[:0]const u8 = null,
+    scale_min: f32 = f32_max,
+    scale_max: f32 = f32_min,
+    graph_size: [2]f32 = .{ 0, 0 },
+    stride: c_int = @sizeOf(f32),
+};
+pub fn plotLines(label: [*:0]const u8, args: PlotNative) void {
+    zguiPlotLines(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+}
+extern fn zguiPlotLines(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
+
+pub fn plotHistogram(label: [*:0]const u8, args: PlotNative) void {
+    zguiPlotHistogram(label, args.v, args.v_count, args.v_offset, args.overlay_text, args.scale_min, args.scale_max, args.graph_size, args.graph_size);
+}
+extern fn zguiPlotHistogram(label: [*:0]const u8, v: *f32, v_count: c_int, v_offset: c_int, overlay_text: ?[:0]const u8, scale_min: f32, scale_max: f32, graph_size: [2]f32, stride: c_int) void;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -4552,10 +4552,10 @@ pub const DrawList = *opaque {
         text_end: [*]const u8,
     ) void;
     const AddTextArgs = struct {
-        font: Font,
+        font: ?Font,
         font_size: f32,
         wrap_width: f32 = 0,
-        cpu_fine_clip_rect: ?[]const [4]f32 = null,
+        cpu_fine_clip_rect: ?[*]const [4]f32 = null,
     };
     pub fn addTextExtended(
         draw_list: DrawList,
@@ -4596,7 +4596,7 @@ pub const DrawList = *opaque {
         text: [*]const u8,
         text_end: [*]const u8,
         wrap_width: f32,
-        cpu_fine_clip_rect: ?[]const [4]f32,
+        cpu_fine_clip_rect: ?[*]const [4]f32,
     ) void;
     //----------------------------------------------------------------------------------------------
     pub fn addPolyline(draw_list: DrawList, points: []const [2]f32, args: struct {

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -1829,7 +1829,7 @@ pub const textLink = zguiTextLink;
 extern fn zguiTextLinkOpenURL(label: [*:0]const u8, url: ?[*:0]const u8) void;
 pub const textLinkOpenURL = zguiTextLinkOpenURL;
 //--------------------------------------------------------------------------------------------------
-const PlotNative = struct {
+const PlotArgs = struct {
     v: [*]f32,
     v_count: c_int,
     v_offset: c_int = 0,
@@ -1839,7 +1839,7 @@ const PlotNative = struct {
     graph_size: [2]f32 = .{ 0, 0 },
     stride: c_int = @sizeOf(f32),
 };
-pub fn plotLines(label: [*:0]const u8, args: PlotNative) void {
+pub fn plotLines(label: [*:0]const u8, args: PlotArgs) void {
     zguiPlotLines(
         label,
         args.v,
@@ -1864,7 +1864,7 @@ extern fn zguiPlotLines(
     stride: c_int,
 ) void;
 
-pub fn plotHistogram(label: [*:0]const u8, args: PlotNative) void {
+pub fn plotHistogram(label: [*:0]const u8, args: PlotArgs) void {
     zguiPlotHistogram(
         label,
         args.v,

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -4551,6 +4551,53 @@ pub const DrawList = *opaque {
         text: [*]const u8,
         text_end: [*]const u8,
     ) void;
+    const AddTextArgs = struct {
+        font: Font,
+        font_size: f32,
+        wrap_width: f32 = 0,
+        cpu_fine_clip_rect: ?[]const [4]f32 = null,
+    };
+    pub fn addTextExtended(
+        draw_list: DrawList,
+        pos: [2]f32,
+        col: u32,
+        comptime fmt: []const u8,
+        args: anytype,
+        add_text_args: AddTextArgs,
+    ) void {
+        const txt = format(fmt, args);
+        addTextExtendedUnformatted(draw_list, pos, col, txt, add_text_args);
+    }
+    pub fn addTextExtendedUnformatted(
+        draw_list: DrawList,
+        pos: [2]f32,
+        col: u32,
+        txt: []const u8,
+        add_text_args: AddTextArgs,
+    ) void {
+        zguiDrawList_AddTextExtended(
+            draw_list,
+            add_text_args.font,
+            add_text_args.font_size,
+            &pos,
+            col,
+            txt.ptr,
+            txt.ptr + txt.len,
+            add_text_args.wrap_width,
+            add_text_args.cpu_fine_clip_rect,
+        );
+    }
+    extern fn zguiDrawList_AddTextExtended(
+        draw_list: DrawList,
+        font: ?Font,
+        font_size: f32,
+        pos: *const [2]f32,
+        col: u32,
+        text: [*]const u8,
+        text_end: [*]const u8,
+        wrap_width: f32,
+        cpu_fine_clip_rect: ?[]const [4]f32,
+    ) void;
     //----------------------------------------------------------------------------------------------
     pub fn addPolyline(draw_list: DrawList, points: []const [2]f32, args: struct {
         col: u32,

--- a/src/zgui.cpp
+++ b/src/zgui.cpp
@@ -1977,6 +1977,36 @@ extern "C"
     {
         ImGui::CloseCurrentPopup();
     }
+
+    ZGUI_API void zguiPlotLines(
+        const char* label, 
+        const float* values, 
+        int values_count, 
+        int values_offset, 
+        const char* overlay_text, 
+        float scale_min, 
+        float scale_max, 
+        float graph_size[2], 
+        int stride)
+    {
+        ImGui::PlotLines(label, values, values_count, values_offset, overlay_text, scale_min, scale_max, ImVec2(graph_size[0], graph_size[1]), stride);
+    }  
+    
+
+    ZGUI_API void zguiPlotHistogram(
+        const char* label, 
+        const float* values, 
+        int values_count, 
+        int values_offset, 
+        const char* overlay_text, 
+        float scale_min, 
+        float scale_max, 
+        float graph_size[2], 
+        int stride)
+    {
+        ImGui::PlotHistogram(label, values, values_count, values_offset, overlay_text, scale_min, scale_max, ImVec2(graph_size[0], graph_size[1]), stride);
+    }
+
     //--------------------------------------------------------------------------------------------------
     //
     // Tables

--- a/src/zgui.cpp
+++ b/src/zgui.cpp
@@ -2519,6 +2519,20 @@ extern "C"
         draw_list->AddText({pos[0], pos[1]}, col, text_begin, text_end);
     }
 
+    ZGUI_API void zguiDrawList_AddTextExtended(
+        ImDrawList *draw_list,
+        ImFont* font, 
+        float font_size, 
+        const float pos[2], 
+        ImU32 col, 
+        const char* text_begin, 
+        const char* text_end, 
+        float wrap_width, 
+        const float cpu_fine_clip_rect[][4])
+    {
+        draw_list->AddText(font, font_size, {pos[0], pos[1]}, col, text_begin, text_end, wrap_width, (const ImVec4 *)&cpu_fine_clip_rect[0][0]);
+    }
+
     ZGUI_API void zguiDrawList_AddPolyline(
         ImDrawList *draw_list,
         const float points[][2],


### PR DESCRIPTION
As proposed in [my issues of missing add text functions variant](https://github.com/zig-gamedev/zgui/issues/54), I have enabled the function with the name addTextExtendedUnformatted and addTextExtended  to handle text drawing with custom font and sizes:

<img width="1128" height="504" alt="image" src="https://github.com/user-attachments/assets/81ab5c14-a501-480f-b6d8-00464447b672" />

As you can see, this update could load and render different fonts, along with changing the clipped region and wrap width defined in an additional struct AddTextArgs. 
```
// Loading the embed font files, and put them into a map for ease of access
try font_map.put("default", zgui.io.addFontFromMemory(FONT_MAIN, std.math.floor(16.0 * scale_factor)));
try font_map.put("wolf", zgui.io.addFontFromMemory(FONT_WOLF, std.math.floor(64.0 * scale_factor)));
try font_map.put("square", zgui.io.addFontFromMemory(FONT_FRSQ, std.math.floor(64.0 * scale_factor)));
try font_map.put("tfat", zgui.io.addFontFromMemory(FONT_TFAT, std.math.floor(64.0 * scale_factor)));

// in the main event loop...
draw_list.addText(pos, 0xffffffff, "This is written by a {s}", .{"human"});
draw_list.addTextExtended(.{ pos[0], pos[1] + 40 }, 0xffffffff, "This is written by a {s}, but Larger", .{"HUMAN"}, .{ .font = null, .font_size = 72 });
draw_list.addTextExtended(.{ pos[0], pos[1] + 120 }, 0x880000ff, "This is written by a {s}", .{"wolf"}, .{ .font = font_map.get("wolf").?, .font_size = 24 });
draw_list.addTextExtended(.{ pos[0], pos[1] + 180 }, 0xffffffff, "This is written by a {s}", .{"...square?"}, .{ .font = font_map.get("square").?, .font_size = 48, .cpu_fine_clip_rect = &.{.{ 50, 0, 1000, 250 }} });
draw_list.addTextExtendedUnformatted(.{ pos[0], pos[1] + 240 }, 0xffffffff, "Analog, Transform and Transmit", .{ .font = font_map.get("tfat").?, .font_size = 48, .wrap_width = window_width });
```

Let's see what would you think about this change.