### PR TITLE
update callconv(.C) calls -> callconv(.c) for zig 0.15.1

### DIFF
--- a/src/backend_dx12.zig
+++ b/src/backend_dx12.zig
@@ -18,12 +18,12 @@ pub const ImGui_ImplDX12_InitInfo = extern struct {
         *ImGui_ImplDX12_InitInfo,
         *D3D12_CPU_DESCRIPTOR_HANDLE,
         *D3D12_GPU_DESCRIPTOR_HANDLE,
-    ) callconv(.C) void = null,
+    ) callconv(.c) void = null,
     srv_desc_free_fn: ?*const fn (
         *ImGui_ImplDX12_InitInfo,
         D3D12_CPU_DESCRIPTOR_HANDLE,
         D3D12_GPU_DESCRIPTOR_HANDLE,
-    ) callconv(.C) void = null,
+    ) callconv(.c) void = null,
     font_srv_cpu_desc_handle: D3D12_CPU_DESCRIPTOR_HANDLE,
     font_srv_gpu_desc_handle: D3D12_GPU_DESCRIPTOR_HANDLE,
 };

--- a/src/backend_glfw_vulkan.zig
+++ b/src/backend_glfw_vulkan.zig
@@ -12,7 +12,7 @@ pub fn init(init_info: ImGui_ImplVulkan_InitInfo, window: *const anyopaque) void
 }
 
 pub fn loadFunctions(
-    loader: fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.C) ?*anyopaque,
+    loader: fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.c) ?*anyopaque,
     user_data: ?*anyopaque,
 ) bool {
     return backend_vulkan.loadFunctions(loader, user_data);

--- a/src/backend_vulkan.zig
+++ b/src/backend_vulkan.zig
@@ -33,7 +33,7 @@ pub const ImGui_ImplVulkan_InitInfo = extern struct {
     pipeline_rendering_create_info: VkPipelineRenderingCreateInfo = .{},
 
     allocator: ?*const anyopaque = null,
-    check_vk_result_fn: ?*const fn (err: u32) callconv(.C) void = null,
+    check_vk_result_fn: ?*const fn (err: u32) callconv(.c) void = null,
     min_allocation_size: u64 = 0,
 };
 
@@ -46,7 +46,7 @@ pub fn init(init_info: ImGui_ImplVulkan_InitInfo) void {
 }
 
 pub fn loadFunctions(
-    loader: fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.C) ?*anyopaque,
+    loader: fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.c) ?*anyopaque,
     user_data: ?*anyopaque,
 ) bool {
     return ImGui_ImplVulkan_LoadFunctions(loader, user_data);
@@ -86,6 +86,6 @@ extern fn ImGui_ImplVulkan_CreateFontsTexture() void;
 extern fn ImGui_ImplVulkan_DestroyFontsTexture() void;
 extern fn ImGui_ImplVulkan_SetMinImageCount(min_image_count: u32) void;
 extern fn ImGui_ImplVulkan_LoadFunctions(
-    loader_func: *const fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.C) ?*anyopaque,
+    loader_func: *const fn (function_name: [*:0]const u8, user_data: ?*anyopaque) callconv(.c) ?*anyopaque,
     user_data: ?*anyopaque,
 ) bool;

--- a/src/node_editor.zig
+++ b/src/node_editor.zig
@@ -111,11 +111,11 @@ const CanvasSizeMode = enum(c_int) {
     CenterOnly, // Previous view will be centered on new view
 };
 
-const SaveNodeSettings = fn (nodeId: NodeId, data: [*]const u8, size: usize, reason: SaveReasonFlags, userPointer: *anyopaque) callconv(.C) bool;
-const LoadNodeSettings = fn (nodeId: NodeId, data: [*]u8, userPointer: *anyopaque) callconv(.C) usize;
-const SaveSettings = fn (data: [*]const u8, size: usize, reason: SaveReasonFlags, userPointer: *anyopaque) callconv(.C) bool;
-const LoadSettings = fn (data: [*]u8, userPointer: *anyopaque) callconv(.C) usize;
-const ConfigSession = fn (userPointer: *anyopaque) callconv(.C) void;
+const SaveNodeSettings = fn (nodeId: NodeId, data: [*]const u8, size: usize, reason: SaveReasonFlags, userPointer: *anyopaque) callconv(.c) bool;
+const LoadNodeSettings = fn (nodeId: NodeId, data: [*]u8, userPointer: *anyopaque) callconv(.c) usize;
+const SaveSettings = fn (data: [*]const u8, size: usize, reason: SaveReasonFlags, userPointer: *anyopaque) callconv(.c) bool;
+const LoadSettings = fn (data: [*]u8, userPointer: *anyopaque) callconv(.c) usize;
+const ConfigSession = fn (userPointer: *anyopaque) callconv(.c) void;
 
 const _ImVector = extern struct {
     Size: c_int = 0,

--- a/src/te.zig
+++ b/src/te.zig
@@ -97,7 +97,7 @@ pub const TestEngine = opaque {
             @intCast(src.line),
             if (std.meta.hasFn(Callbacks, "gui"))
                 struct {
-                    fn f(context: *TestContext) callconv(.C) void {
+                    fn f(context: *TestContext) callconv(.c) void {
                         Callbacks.gui(context) catch undefined;
                     }
                 }.f
@@ -105,7 +105,7 @@ pub const TestEngine = opaque {
                 null,
             if (std.meta.hasFn(Callbacks, "run"))
                 struct {
-                    fn f(context: *TestContext) callconv(.C) void {
+                    fn f(context: *TestContext) callconv(.c) void {
                         Callbacks.run(context) catch undefined;
                     }
                 }.f
@@ -207,8 +207,8 @@ pub const TestContext = opaque {
     extern fn zguiTe_ContextKeyUp(ctx: *TestContext, key_chord: c_int) void;
 };
 
-const ImGuiTestGuiFunc = fn (context: *TestContext) callconv(.C) void;
-const ImGuiTestTestFunc = fn (context: *TestContext) callconv(.C) void;
+const ImGuiTestGuiFunc = fn (context: *TestContext) callconv(.c) void;
+const ImGuiTestTestFunc = fn (context: *TestContext) callconv(.c) void;
 
 pub const createContext = zguiTe_CreateContext;
 extern fn zguiTe_CreateContext() *TestEngine;


### PR DESCRIPTION
Ran into a build error when trying to use zgui with vulkan, noticed that some `callconv(.c)` calls were still `callconv(.C)` .

This is a find and replace of all instances to `callconv(.c)` for zig `0.15.1`.

Cheers!