### PR TITLE
Update ArrayList functions to take an allocator when necessary 

### DIFF
--- a/src/gui.zig
+++ b/src/gui.zig
@@ -72,7 +72,7 @@ pub fn initWithExistingContext(allocator: std.mem.Allocator, ctx: Context) void 
     zguiSetCurrentContext(ctx);
 
     temp_buffer = std.ArrayList(u8){};
-    temp_buffer.?.resize(3 * 1024 + 1) catch unreachable;
+    temp_buffer.?.resize(mem_allocator.?, 3 * 1024 + 1) catch unreachable;
 
     if (te_enabled) {
         te.init();


### PR DESCRIPTION
With the ArrayList API in zig 0.15.1, it is required to pass an allocator as the first argument to the resize function. The same goes for the deinit function. 