### PR TITLE
Fix InputTextCallback segfault: added callconv(.c)

### DIFF
--- a/src/gui.zig
+++ b/src/gui.zig
@@ -2741,7 +2741,7 @@ pub const InputTextCallbackData = extern struct {
     }
 };
 
-pub const InputTextCallback = *const fn (data: *InputTextCallbackData) i32;
+pub const InputTextCallback = *const fn (data: *InputTextCallbackData) callconv(.c) i32;
 //--------------------------------------------------------------------------------------------------
 pub fn inputText(label: [:0]const u8, args: struct {
     buf: [:0]u8,


### PR DESCRIPTION
Added callconv(.c) to the callback type; otherwise it would segfault when called. This also means the callback function in your code must be declared with callconv(.c). This fixes issue #45 