### PR TITLE
Include emscripten sysroot with no backend option.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -441,7 +441,13 @@ pub fn build(b: *std.Build) void {
                 .flags = cflags,
             });
         },
-        .no_backend => {},
+        .no_backend => {
+            if (emscripten) {
+                imgui.root_module.addSystemIncludePath(.{
+                    .cwd_relative = b.pathJoin(&.{b.sysroot.?, "include"})
+                });
+            }
+        },
     }
 
     if (target.result.os.tag == .macos) {


### PR DESCRIPTION
This change fixes an issue for users compiling with emscripten when no backend is selected. In the dependent build.zig a user can set `zgui.builder.sysroot = <emscripten_sysroot>` which will then compile imgui with the necessary headers. Without this change the imgui compilation step is unable to locate <assert.h>.

### Context:
I am trying to add zgui to my existing project which uses raylib.  In order to do this I need to use the [rlImgui](https://github.com/raylib-extras/rlImGui) backend and compile zgui with no backend. This worked out of the box for native builds but broke my wasm build.