### PR TITLE
Fix to work with zig 0.17.0-dev.304+9787df942

### DIFF
--- a/src/gui.zig
+++ b/src/gui.zig
@@ -2012,7 +2012,7 @@ pub fn comboFromEnum(
         @compileError("Error: current_item must be a pointer-to-an-enum, not a " ++ @TypeOf(EnumType));
     };
 
-    const FieldNameIndex = std.meta.Tuple(&.{ []const u8, i32 });
+    const FieldNameIndex = @Tuple(&.{ []const u8, i32 });
     comptime var item_names: [:0]const u8 = "";
     comptime var field_name_to_index_list: [enum_type_info.fields.len]FieldNameIndex = undefined;
     comptime var index_to_enum: [enum_type_info.fields.len]EnumType = undefined;


### PR DESCRIPTION
It's unclear to me why I don't need #103, but all the tests compile and pass
with this lil change, and with https://github.com/zig-gamedev/zgpu/pull/29 via
`--fork` flag.
