### PR TITLE
Fix missing GameController framework linking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -381,6 +381,7 @@ pub fn build(b: *std.Build) void {
             imgui_mod.linkFramework("Metal", .{});
             imgui_mod.linkFramework("Cocoa", .{});
             imgui_mod.linkFramework("QuartzCore", .{});
+            imgui_mod.linkFramework("GameController", .{});
             imgui_mod.addCSourceFiles(.{
                 .files = &.{
                     "libs/imgui/backends/imgui_impl_osx.mm",


### PR DESCRIPTION
Building imgui with the `osx_metal` backend fails with the following linker error:

```
error: undefined symbol: _OBJC_CLASS_$_GCController
```
96cf8bd517043cbfbc018908c8049184ee6af29e introduced the use of GCController, so the GameController framework must be linked.
